### PR TITLE
add PL Trainer options to configs: (fixes.)

### DIFF
--- a/sgnn_pl085_hydra/configs/PL/pytorch_lightning.yaml
+++ b/sgnn_pl085_hydra/configs/PL/pytorch_lightning.yaml
@@ -1,6 +1,8 @@
 # @package _group_
 
 #  https://pytorch-lightning.readthedocs.io/en/latest/trainer.html# trainer-class
+# Remarks:
+#  - all None fields are commented, as hydra treats them as string.
 
 gpus: 1
 distributed_backend: dp
@@ -18,7 +20,7 @@ gradient_clip_val: 0
 # gpus: None
 # auto_select_gpus: False
 # tpu_cores: None
-log_gpu_memory: None
+# log_gpu_memory: None
 # progress_bar_refresh_rate: 1
 overfit_batches: 0.0
 # track_grad_norm: -1
@@ -27,8 +29,8 @@ overfit_batches: 0.0
 accumulate_grad_batches: 1
 # #  max_epochs: 1000  #  use train.max_epochs
 # min_epochs: 1
-max_steps: None
-min_steps: None
+# max_steps: None
+# min_steps: None
 limit_train_batches: 1.0
 limit_val_batches: 1.0
 limit_test_batches: 1.0
@@ -38,11 +40,11 @@ row_log_interval: 50
 # distributed_backend: None
 # precision: 32
 weights_summary: 'top'
-weights_save_path: None
+# weights_save_path: None
 num_sanity_val_steps: 2
-truncated_bptt_steps: None
-resume_from_checkpoint: None
-profiler: None
+# truncated_bptt_steps: None
+# resume_from_checkpoint: None
+# profiler: None
 benchmark: False
 deterministic: False
 reload_dataloaders_every_epoch: False
@@ -52,7 +54,7 @@ terminate_on_nan: False
 auto_scale_batch_size: False
 prepare_data_per_node: True
 amp_level: 'O2'
-val_percent_check: None
-test_percent_check: None
-train_percent_check: None
-overfit_pct: None
+# val_percent_check: None    Depricated
+# test_percent_check: None
+# train_percent_check: None
+# overfit_pct: None

--- a/sgnn_pl085_hydra/train.py
+++ b/sgnn_pl085_hydra/train.py
@@ -116,17 +116,20 @@ def main(hparams):
         # ------------------------
         cfg = hparams.PL
 
-        logger = tracker
         if tracker is None:
-            logger = True # cfg.logger
+            cfg.logger = tracker
+        print(cfg.overfit_batches)
+        print(type(cfg.overfit_batches))
+        print(dir(cfg))
+
+        kwargs = dict(cfg)
+        print(kwargs['overfit_batches'])
+        print(type(kwargs['overfit_batches']))
 
         trainer = pl.Trainer(
             max_epochs=hparams.train.max_epochs,
-            gpus=cfg.gpus,
-            distributed_backend=cfg.distributed_backend,
-            precision=cfg.precision,
-            logger=logger,
             callbacks=callbacks,
+            **dict(cfg)
         )
 
         # ------------------------


### PR DESCRIPTION
Pass the parameters described in hydra conf to PL Trainer.

Remarks
all None fields of PL options are commented on because Hydra considers them as strings.