### PR TITLE
hydra: use strings, lists. add None

### DIFF
--- a/sgnn_pl085_hydra/configs/example_01.yaml
+++ b/sgnn_pl085_hydra/configs/example_01.yaml
@@ -12,7 +12,7 @@ save: ./logs
 
 tracker:
     experiment_name: test
-    tags: "sgnn/test"
+    tags: ["sgnn", "test"]
     offline: False
     neptune:
         fn_token: ~/.NEPTUNE_API_TOKEN.txt

--- a/sgnn_pl085_hydra/configs/example_02.yaml
+++ b/sgnn_pl085_hydra/configs/example_02.yaml
@@ -9,7 +9,9 @@ data:
 save: ./logs
 
 tracker:
-    experiment_name: test2
+    experiment_name: "test2 config2"
+    tags: ["sgnn", "test2"]
+    offline: False
     neptune:
         fn_token: ~/.NEPTUNE_API_TOKEN.txt
         project_name: "goodok/sgnn"

--- a/sgnn_pl085_hydra/run_hydra_01.sh
+++ b/sgnn_pl085_hydra/run_hydra_01.sh
@@ -1,2 +1,3 @@
 #HYDRA_FULL_ERROR=1  python train.py
-CUDA_VISIBLE_DEVICES="0" python train.py $@
+CUDA_VISIBLE_DEVICES="0" python train.py "$@"
+

--- a/sgnn_pl085_hydra/run_hydra_04.sh
+++ b/sgnn_pl085_hydra/run_hydra_04.sh
@@ -1,1 +1,1 @@
-CUDA_VISIBLE_DEVICES="1" python train.py $@
+CUDA_VISIBLE_DEVICES="1" python train.py "$@"

--- a/sgnn_pl085_hydra/train.py
+++ b/sgnn_pl085_hydra/train.py
@@ -67,7 +67,7 @@ def main(hparams):
 
         hparams_flatten = dict_flatten(hparams, sep='.')
         experiment_name = hparams.tracker.get('experiment_name', None)
-        tags = hparams.tracker.get('tags', '').split('/')
+        tags = list(hparams.tracker.get('tags', []))
         offline_mode = hparams.tracker.get('offline', False)
 
         tracker = NeptuneLogger(


### PR DESCRIPTION
- Use lists, e.g. for tracker.tags
-  fix *.sh files to maintain string with spaces in bash.

#### Notes:

**"None"**

Use '+' in command line to add fileds which are undescribed in config's yaml

    $ python run.py +tracker.newfield=1


**List or tuple**

Don't use ' ' (spaces) in command line

    # ['aaa','bbb'] instead of ['aaa', 'bbb']

    $ python run.py tracker.tags=['sgnn','test']


**Stings**

Use '" "' in command lines

    $ python run.py tracker.description='"dd  dd"'

And in bash *.sh use quotes around "$@"


#### See also documentation:


https://hydra.cc/docs/next/advanced/command_line_syntax/


#### Full example:

    sh run_hydra_04.sh +tracker.test=1 tracker.tags=['sgnn','debug'] tracker.experiment_name='"Debug lists, strings"' tracker.offline=True

or

    CUDA_VISIBLE_DEVICES="1" python train.py +tracker.test=1 tracker.tags=['sgnn','debug'] tracker.experiment_name='"Debug lists, strings"' tracker.offline=True